### PR TITLE
Rework chunk parsing in order to avoid repeatedly re-reading data

### DIFF
--- a/scripts/run_tractor.R
+++ b/scripts/run_tractor.R
@@ -253,11 +253,9 @@ RunTractor <- function(prefix, phenofile, sampleidcol, phenocol, covarcollist, c
   inPipes = lapply(inFiles, function(file) {
     if (!endsWith(file,".gz")) {
       con <- pipe(sprintf("cat %s", shQuote(file)), open="r")
-      on.exit(try(close(con), silent=TRUE))
       return(con)
     } else {
       con <- pipe(sprintf("gzip -cd %s", shQuote(file)), open="r")
-      on.exit(try(close(con), silent=TRUE))
       return(con)
     }
   })
@@ -430,7 +428,12 @@ RunTractor <- function(prefix, phenofile, sampleidcol, phenocol, covarcollist, c
     # Updating looping variables
     iters    = iters + 1
   }
+
+  lapply(inPipes, function(pipe) {
+    try(close(pipe), silent=TRUE)
+  })
 }
+
 
 RunTractor(prefix = opt$hapdose,
            phenofile = opt$phenofile,


### PR DESCRIPTION
I observed that skip in data.table::fread is very slow, and that the developers of data.table advise that skip should not be used for chunking: https://github.com/Rdatatable/data.table/issues/1721

This change will use pipes to incrementally read the input files in chunks instead of repeatedly decompressing and re-reading the files. This should enable much smaller chunk sizes, which will significantly reduce memory usage.